### PR TITLE
Update rescue from Cancancan with head :forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+## Changed
+- Update rescue from Cancancan with head :forbidden (since Rails4 instead of render :nothing)
 
+## Pushed 2016-09-17
+no problems with heroku!
 ### Changed 
 - Removed cancancan loading and auth from :index, because :index already has a user/guest-check.
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,9 @@ class ApplicationController < ActionController::Base
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
-      format.json { render nothing: true, status: :forbidden }
+      format.json { head :forbidden, content_type: "text/html" }
       format.html { redirect_to main_app.root_url, :notice => exception.message }
-      format.js   { render nothing: true, status: :forbidden }
+      format.js   { head :forbidden, content_type: "text/html"}
     end
   end
 


### PR DESCRIPTION
Since Rails4 head is preferred over render nothing. In Rails 5.1 render nothing will be deprecated.
Solves issue #50 