### PR TITLE
FIX Edit account throwing error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Fixed
+- Account was not accessible, Devise throwing an error. Fixed in :authenticate_user! 
+
 ## Changed
 - Update rescue from Cancancan with head :forbidden (since Rails4 instead of render :nothing)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,8 @@ class ApplicationController < ActionController::Base
   end
 
   # override Devise to allow for 'soft sign-up'
-  def authenticate_account!
-    current_account.present?
+  def authenticate_account!(*args)
+    current_account.present? || super(*args)
   end
 
   def current_account


### PR DESCRIPTION
Devise expects no arguments in authenticate_error, and it got 1. Solved by passing (options={}) or (*args). I chose *args, plus fallback to super. (As documented in bignerd blog post: https://www.bignerdranch.com/blog/lazy-user-registration-for-rails-apps/

It worked also with the options hash, and it works also without the fallback to ( || super(*args). Because we always create a new account when someone enters the homepage. 