### PR TITLE
Project tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Added
+- Add project tags to snippet.
+
 ## Fixed
 - Account was not accessible, Devise throwing an error. Fixed in :authenticate_user! 
 

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -15,9 +15,11 @@ class SnippetsController < ApplicationController
     end
 
     if params[:search]
-      @snippets = @snippets.search(params[:search])
+      @snippets = @snippets.search(params[:search]).reverse
     elsif params[:tag]
       @snippets = @snippets.tagged_with(params[:tag]).reverse_order
+    elsif params[:project]
+      @snippets = @snippets.tagged_with(params[:project])
     end
   end
 
@@ -84,6 +86,6 @@ class SnippetsController < ApplicationController
   private
     # Never trust parameters from the scary internet, only allow the white list through.
     def snippet_params
-      params.require(:snippet).permit(:title, :content, :tag_list, :image, :remove_image)
+      params.require(:snippet).permit(:title, :content, :tag_list, :project_list, :image, :remove_image)
     end
 end

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -15,7 +15,7 @@ class SnippetsController < ApplicationController
     end
 
     if params[:search]
-      @snippets = @snippets.search(params[:search]).reverse_order
+      @snippets = @snippets.search(params[:search])
     elsif params[:tag]
       @snippets = @snippets.tagged_with(params[:tag]).reverse_order
     end

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -3,11 +3,14 @@ class Snippet < ApplicationRecord
   belongs_to :account
 
   acts_as_taggable_on :tags # tagging gem
+  acts_as_taggable_on :projects
 
   mount_uploader :image, ImageUploader # carrierwave gem
 
   def self.search(search)
-    where("title ILIKE ? OR content ILIKE ?", "%#{search}%", "%#{search}%")
+    q_words = Snippet.where("title ILIKE ? OR content ILIKE ?", "%#{search}%", "%#{search}%")
+    q_tags = Snippet.tagged_with("#{search}")
+    q_words + q_tags
   end
 
 end

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -9,8 +9,8 @@ class Snippet < ApplicationRecord
 
   def self.search(search)
     q_words = Snippet.where("title ILIKE ? OR content ILIKE ?", "%#{search}%", "%#{search}%")
-    q_tags = Snippet.tagged_with("#{search}")
-    q_words + q_tags
+    # q_tags = Snippet.tagged_with(tag: "#{search}")
+    # q_words + q_tags
   end
 
 end

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -26,6 +26,7 @@
           <i class ='fa fa-tag'></i>
         </div>
         <%= f.text_field :tag_list, placeholder: 'tag1, tag2, one tag, ', value: @snippet.tag_list.to_s%>
+        <%= f.text_field :project_list, value: @snippet.project_list.to_s %>
       </div>
 
         <%= f.label :content, class: 'sr-only' %>

--- a/app/views/snippets/index.html.erb
+++ b/app/views/snippets/index.html.erb
@@ -27,7 +27,7 @@
       </div>
       <div class="card-footer text-muted">
 
-        <i class ='fa fa-tag'></i> <%= raw snippet.tag_list.map { |tag| link_to tag, tag_path(tag) }.join(', ') %>  |  <%= raw snippet.project_list.map { |project| link_to project, tag_path(project) }.join(', ') %>   |  <%= link_to snippet, method: :delete, data: { confirm: 'Are you sure?' }, remote: true do %>
+        <i class ='fa fa-tag'></i> <%= raw snippet.tag_list.map { |tag| link_to tag, tag_path(tag) }.join(', ') %>  | <%= raw snippet.project_list.map { |project| link_to project, tag_path(project) }.join(', ') %>   |  <%= link_to snippet, method: :delete, data: { confirm: 'Are you sure?' }, remote: true do %>
             <i class="fa fa-trash-o pull-right grey-link" style='position: relative; top: 5px' aria-hidden="true"></i>
         <% end %>
         <%#= snippet.project_list.map %>

--- a/app/views/snippets/index.html.erb
+++ b/app/views/snippets/index.html.erb
@@ -27,9 +27,10 @@
       </div>
       <div class="card-footer text-muted">
 
-        <i class ='fa fa-tag'></i> <%= raw snippet.tag_list.map { |tag| link_to tag, tag_path(tag) }.join(', ') %> <%= link_to snippet, method: :delete, data: { confirm: 'Are you sure?' }, remote: true do %>
+        <i class ='fa fa-tag'></i> <%= raw snippet.tag_list.map { |tag| link_to tag, tag_path(tag) }.join(', ') %>  |  <%= raw snippet.project_list.map { |project| link_to project, tag_path(project) }.join(', ') %>   |  <%= link_to snippet, method: :delete, data: { confirm: 'Are you sure?' }, remote: true do %>
             <i class="fa fa-trash-o pull-right grey-link" style='position: relative; top: 5px' aria-hidden="true"></i>
         <% end %>
+        <%#= snippet.project_list.map %>
       </div>
     </div><!-- /.card -->
   <% end %><!-- end of snippets -->


### PR DESCRIPTION
- Add project tags as a separate kind of tag. 
- Deactivate searching in tags as long as it is not clear if search query is safe to SQLi.