### PR TITLE
Fix file upload

### DIFF
--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @snippet, remote: true do |f| %>
+<%= form_for @snippet do |f| %>
 
     <div class="snippet-card">
       <div class="card-block">
@@ -8,6 +8,11 @@
         <div class="form-inputs" style="text-align: left">
           <%= f.trix_editor :content, rows: 15 %>
         </div>
+        <div><small class="form-text">Add an image</small>
+          <%= f.file_field :image, class: 'form-control', id: 'new_image' %>
+          <%#= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <small><%= f.label :remove_image %></small>
+          <%= f.check_box :remove_image, class: 'checkbox inline' %></div>
       </div>
 
       <div class="input-group">

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -10,7 +10,6 @@
         </div>
         <div><small class="form-text">Add an image</small>
           <%= f.file_field :image, class: 'form-control', id: 'new_image' %>
-          <%#= hidden_field_tag :authenticity_token, form_authenticity_token %>
           <small><%= f.label :remove_image %></small>
           <%= f.check_box :remove_image, class: 'checkbox inline' %></div>
       </div>


### PR DESCRIPTION
Recurring bug, where file uploads are not working. Due to something with the auth token. 
Solved by removing `remote: true` from form head. 